### PR TITLE
feat: add Virtual Network Interface (VNI) management support

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1136,6 +1136,78 @@ class VPCManager:
             logger.error(f"Error listing VPN server clients for {vpn_server_id} in region {region}: {e}")
             raise
 
+    async def list_virtual_network_interfaces(self, region: str, resource_group_id: Optional[str] = None, limit: int = 50, start: Optional[str] = None) -> Dict[str, Any]:
+        """List virtual network interfaces in a region"""
+        try:
+            service = self._get_vpc_client(region)
+
+            kwargs = {"limit": limit}
+            if start:
+                kwargs["start"] = start
+            if resource_group_id:
+                kwargs["resource_group_id"] = resource_group_id
+
+            response = service.list_virtual_network_interfaces(**kwargs).get_result()
+            vnis = response.get('virtual_network_interfaces', [])
+
+            for vni in vnis:
+                vni['region'] = region
+
+            return {
+                'virtual_network_interfaces': vnis,
+                'count': len(vnis),
+                'region': region,
+                'total_count': response.get('total_count', len(vnis)),
+                'limit': response.get('limit', limit)
+            }
+
+        except ApiException as e:
+            logger.error(f"Error listing virtual network interfaces in region {region}: {e}")
+            raise
+
+    async def get_virtual_network_interface(self, vni_id: str, region: str) -> Dict[str, Any]:
+        """Get detailed information about a specific virtual network interface"""
+        try:
+            service = self._get_vpc_client(region)
+            response = service.get_virtual_network_interface(vni_id).get_result()
+
+            response['region'] = region
+
+            return response
+
+        except ApiException as e:
+            logger.error(f"Error getting virtual network interface {vni_id} in region {region}: {e}")
+            raise
+
+    async def list_virtual_network_interface_ips(self, vni_id: str, region: str, limit: int = 50, start: Optional[str] = None, sort: Optional[str] = None) -> Dict[str, Any]:
+        """List reserved IPs bound to a virtual network interface"""
+        try:
+            service = self._get_vpc_client(region)
+
+            kwargs = {"limit": limit}
+            if start:
+                kwargs["start"] = start
+            if sort:
+                kwargs["sort"] = sort
+
+            response = service.list_virtual_network_interface_ips(vni_id, **kwargs).get_result()
+            ips = response.get('ips', [])
+
+            for ip in ips:
+                ip['region'] = region
+
+            return {
+                'virtual_network_interface_id': vni_id,
+                'ips': ips,
+                'count': len(ips),
+                'region': region,
+                'total_count': response.get('total_count', len(ips))
+            }
+
+        except ApiException as e:
+            logger.error(f"Error listing IPs for virtual network interface {vni_id} in region {region}: {e}")
+            raise
+
     async def list_vpn_server_routes(self, vpn_server_id: str, region: str, limit: int = 50, start: Optional[str] = None) -> Dict[str, Any]:
         """List routes for a VPN server"""
         try:

--- a/vpc_mcp_server.py
+++ b/vpc_mcp_server.py
@@ -953,10 +953,84 @@ class VPCMCPServer:
                 },
                 "required": ["vpn_server_id", "region"]
             }
+        ),
+        Tool(
+            name="list_virtual_network_interfaces",
+            description="List virtual network interfaces (VNIs) in a region",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "region": {
+                        "type": "string",
+                        "description": "Region name"
+                    },
+                    "resource_group_id": {
+                        "type": "string",
+                        "description": "Filter by resource group ID"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "description": "Maximum number of VNIs to return (default 50)"
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "Pagination start token"
+                    }
+                },
+                "required": ["region"]
+            }
+        ),
+        Tool(
+            name="get_virtual_network_interface",
+            description="Get detailed information about a specific virtual network interface (VNI)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "vni_id": {
+                        "type": "string",
+                        "description": "Virtual network interface ID"
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Region name"
+                    }
+                },
+                "required": ["vni_id", "region"]
+            }
+        ),
+        Tool(
+            name="list_virtual_network_interface_ips",
+            description="List reserved IPs bound to a virtual network interface (VNI)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "vni_id": {
+                        "type": "string",
+                        "description": "Virtual network interface ID"
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Region name"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "description": "Maximum number of IPs to return (default 50)"
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "Pagination start token"
+                    },
+                    "sort": {
+                        "type": "string",
+                        "description": "Sort field (e.g., 'address', 'name')"
+                    }
+                },
+                "required": ["vni_id", "region"]
+            }
         )
     ]
-    
-        
+
+
         @self.server.call_tool()
         async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             try:
@@ -1182,6 +1256,26 @@ class VPCMCPServer:
                 elif name == "list_vpn_server_clients":
                     result = await self.vpc_manager.list_vpn_server_clients(
                         arguments['vpn_server_id'],
+                        arguments['region'],
+                        arguments.get('limit', 50),
+                        arguments.get('start'),
+                        arguments.get('sort')
+                    )
+                elif name == "list_virtual_network_interfaces":
+                    result = await self.vpc_manager.list_virtual_network_interfaces(
+                        arguments['region'],
+                        arguments.get('resource_group_id'),
+                        arguments.get('limit', 50),
+                        arguments.get('start')
+                    )
+                elif name == "get_virtual_network_interface":
+                    result = await self.vpc_manager.get_virtual_network_interface(
+                        arguments['vni_id'],
+                        arguments['region']
+                    )
+                elif name == "list_virtual_network_interface_ips":
+                    result = await self.vpc_manager.list_virtual_network_interface_ips(
+                        arguments['vni_id'],
                         arguments['region'],
                         arguments.get('limit', 50),
                         arguments.get('start'),


### PR DESCRIPTION
Closes #3

## Summary
- Added `list_virtual_network_interfaces` tool — lists VNIs in a region with optional resource group filtering and pagination
- Added `get_virtual_network_interface` tool — fetches full details for a specific VNI by ID
- Added `list_virtual_network_interface_ips` tool — lists reserved IPs bound to a VNI with optional sort/pagination

## Test plan
- [ ] `list_virtual_network_interfaces` returns VNIs for a given region
- [ ] `list_virtual_network_interfaces` correctly filters by `resource_group_id` when provided
- [ ] `get_virtual_network_interface` returns details for a valid VNI ID
- [ ] `list_virtual_network_interface_ips` returns IPs for a given VNI
- [ ] All three tools return a proper error when given an invalid ID/region

🤖 Generated with [Claude Code](https://claude.com/claude-code)