### PR TITLE
feat: add Flow Log collector support

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1208,6 +1208,107 @@ class VPCManager:
             logger.error(f"Error listing IPs for virtual network interface {vni_id} in region {region}: {e}")
             raise
 
+    async def list_flow_log_collectors(self, region: str, vpc_id: Optional[str] = None,
+                                        resource_group_id: Optional[str] = None,
+                                        name: Optional[str] = None,
+                                        target_id: Optional[str] = None,
+                                        target_resource_type: Optional[str] = None,
+                                        limit: int = 50, start: Optional[str] = None) -> Dict[str, Any]:
+        """List flow log collectors in a region"""
+        try:
+            service = self._get_vpc_client(region)
+
+            kwargs = {"limit": limit}
+            if start:
+                kwargs["start"] = start
+            if vpc_id:
+                kwargs["vpc_id"] = vpc_id
+            if resource_group_id:
+                kwargs["resource_group_id"] = resource_group_id
+            if name:
+                kwargs["name"] = name
+            if target_id:
+                kwargs["target_id"] = target_id
+            if target_resource_type:
+                kwargs["target_resource_type"] = target_resource_type
+
+            response = service.list_flow_log_collectors(**kwargs).get_result()
+            collectors = response.get('flow_log_collectors', [])
+
+            for collector in collectors:
+                collector['region'] = region
+
+            return {
+                'flow_log_collectors': collectors,
+                'count': len(collectors),
+                'region': region,
+                'total_count': response.get('total_count', len(collectors)),
+                'limit': response.get('limit', limit)
+            }
+
+        except ApiException as e:
+            logger.error(f"Error listing flow log collectors in region {region}: {e}")
+            raise
+
+    async def get_flow_log_collector(self, flow_log_collector_id: str, region: str) -> Dict[str, Any]:
+        """Get detailed information about a specific flow log collector"""
+        try:
+            service = self._get_vpc_client(region)
+            response = service.get_flow_log_collector(flow_log_collector_id).get_result()
+            response['region'] = region
+            return response
+
+        except ApiException as e:
+            logger.error(f"Error getting flow log collector {flow_log_collector_id} in region {region}: {e}")
+            raise
+
+    async def analyze_flow_log_collectors(self, region: str, vpc_id: Optional[str] = None) -> Dict[str, Any]:
+        """Analyze flow log collectors in a region, grouped by target resource type"""
+        try:
+            collectors_result = await self.list_flow_log_collectors(region, vpc_id=vpc_id, limit=100)
+            collectors = collectors_result.get('flow_log_collectors', [])
+
+            active = [c for c in collectors if c.get('active', False)]
+            inactive = [c for c in collectors if not c.get('active', False)]
+
+            by_target_type: Dict[str, Any] = {}
+            for collector in collectors:
+                target = collector.get('target', {})
+                resource_type = target.get('resource_type', 'unknown')
+                by_target_type.setdefault(resource_type, []).append({
+                    'id': collector.get('id'),
+                    'name': collector.get('name'),
+                    'active': collector.get('active'),
+                    'storage_bucket': collector.get('storage_bucket', {}).get('name'),
+                    'target_id': target.get('id'),
+                    'target_name': target.get('name'),
+                    'created_at': collector.get('created_at'),
+                    'lifecycle_state': collector.get('lifecycle_state')
+                })
+
+            return {
+                'region': region,
+                'vpc_id': vpc_id,
+                'total_collectors': len(collectors),
+                'active_count': len(active),
+                'inactive_count': len(inactive),
+                'collectors_by_target_type': by_target_type,
+                'summary': {
+                    'active_collectors': [
+                        {'id': c.get('id'), 'name': c.get('name'), 'target': c.get('target', {}).get('name')}
+                        for c in active
+                    ],
+                    'inactive_collectors': [
+                        {'id': c.get('id'), 'name': c.get('name'), 'target': c.get('target', {}).get('name')}
+                        for c in inactive
+                    ]
+                }
+            }
+
+        except ApiException as e:
+            logger.error(f"Error analyzing flow log collectors in region {region}: {e}")
+            raise
+
     async def list_vpn_server_routes(self, vpn_server_id: str, region: str, limit: int = 50, start: Optional[str] = None) -> Dict[str, Any]:
         """List routes for a VPN server"""
         try:

--- a/vpc_mcp_server.py
+++ b/vpc_mcp_server.py
@@ -1027,7 +1027,85 @@ class VPCMCPServer:
                 },
                 "required": ["vni_id", "region"]
             }
-        )
+        ),
+        Tool(
+            name="list_flow_log_collectors",
+            description="List flow log collectors in a region with optional filtering",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "region": {
+                        "type": "string",
+                        "description": "Region name"
+                    },
+                    "vpc_id": {
+                        "type": "string",
+                        "description": "Filter by VPC ID (optional)"
+                    },
+                    "resource_group_id": {
+                        "type": "string",
+                        "description": "Filter by resource group ID (optional)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Filter by collector name (optional)"
+                    },
+                    "target_id": {
+                        "type": "string",
+                        "description": "Filter by target resource ID (optional)"
+                    },
+                    "target_resource_type": {
+                        "type": "string",
+                        "description": "Filter by target resource type: instance, network_interface, subnet, vpc (optional)"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "description": "Maximum number of collectors to return (default 50)"
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "Pagination start token"
+                    }
+                },
+                "required": ["region"]
+            }
+        ),
+        Tool(
+            name="get_flow_log_collector",
+            description="Get detailed information about a specific flow log collector",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "flow_log_collector_id": {
+                        "type": "string",
+                        "description": "Flow log collector ID"
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Region name"
+                    }
+                },
+                "required": ["flow_log_collector_id", "region"]
+            }
+        ),
+        Tool(
+            name="analyze_flow_log_collectors",
+            description="Analyze flow log collectors in a region, showing active/inactive status grouped by target resource type",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "region": {
+                        "type": "string",
+                        "description": "Region name"
+                    },
+                    "vpc_id": {
+                        "type": "string",
+                        "description": "Filter by VPC ID (optional)"
+                    }
+                },
+                "required": ["region"]
+            }
+        ),
     ]
 
 
@@ -1280,6 +1358,27 @@ class VPCMCPServer:
                         arguments.get('limit', 50),
                         arguments.get('start'),
                         arguments.get('sort')
+                    )
+                elif name == "list_flow_log_collectors":
+                    result = await self.vpc_manager.list_flow_log_collectors(
+                        arguments['region'],
+                        arguments.get('vpc_id'),
+                        arguments.get('resource_group_id'),
+                        arguments.get('name'),
+                        arguments.get('target_id'),
+                        arguments.get('target_resource_type'),
+                        arguments.get('limit', 50),
+                        arguments.get('start')
+                    )
+                elif name == "get_flow_log_collector":
+                    result = await self.vpc_manager.get_flow_log_collector(
+                        arguments['flow_log_collector_id'],
+                        arguments['region']
+                    )
+                elif name == "analyze_flow_log_collectors":
+                    result = await self.vpc_manager.analyze_flow_log_collectors(
+                        arguments['region'],
+                        arguments.get('vpc_id')
                     )
                 else:
                     raise ValueError(f"Unknown tool: {name}")


### PR DESCRIPTION
## Summary

Implements read-only Flow Log collector management (closes #6) via three new MCP tools:

- **`list_flow_log_collectors`** — list collectors in a region with optional filtering by `vpc_id`, `resource_group_id`, `name`, `target_id`, and `target_resource_type`
- **`get_flow_log_collector`** — retrieve full details for a specific collector by ID
- **`analyze_flow_log_collectors`** — summarize active/inactive collector counts and group collectors by target resource type

## Changes

- `utils.py`: 3 new async `VPCManager` methods wrapping the IBM VPC SDK flow log collector APIs
- `vpc_mcp_server.py`: 3 new `Tool` definitions registered in `list_tools` and routed in `call_tool`

## Test plan

- [ ] Syntax validated: `python -m py_compile` passes for both files
- [ ] Existing test suite: 41/43 pass (2 pre-existing failures in `analyze_backup_policy_health` unrelated to this change)
- [ ] Manual: `list_flow_log_collectors` with region filter
- [ ] Manual: `get_flow_log_collector` with a known collector ID
- [ ] Manual: `analyze_flow_log_collectors` to verify active/inactive grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)