### PR TITLE
feat: add Transit Gateway support to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,328 +1,69 @@
 # IBM Cloud VPC MCP Server
 
-A Model Context Protocol (MCP) server that provides comprehensive IBM Cloud VPC resource management and security analysis capabilities. This server enables seamless interaction with IBM Cloud VPC infrastructure through a standardized protocol interface.
+An MCP server for IBM Cloud VPC resource management. Exposes VPC infrastructure — instances, networking, storage, VPN, flow logs, transit gateways, and more — as tools consumable by Claude Desktop or Claude Code.
 
-## 🚀 Features
+## Prerequisites
 
-### Core VPC Management
-- **Multi-region Support**: List and manage VPCs across all IBM Cloud regions
-- **Resource Discovery**: Comprehensive listing of VPCs, subnets, instances, and security groups
-- **Instance Management**: View instance profiles, status, and network configurations
-- **Network Infrastructure**: Manage public gateways, floating IPs, and network interfaces
+- Docker
+- IBM Cloud API key with VPC permissions
 
-### Enhanced Capabilities
-- **Real-time Data**: Live data from IBM Cloud APIs with intelligent caching
-- **Filtering Support**: Filter resources by VPC, region, or other criteria
-- **Detailed Summaries**: Complete resource summaries with security analysis
-- **Error Handling**: Robust error handling and logging
+## Build
 
-## 📋 Prerequisites
+```bash
+docker build -t ibmcloud-vpc-mcp:latest .
+```
 
-- **IBM Cloud Account**: Active IBM Cloud account with VPC access
-- **API Key**: IBM Cloud API key with VPC management permissions
-- **Docker**: For containerized deployment
-- **Python 3.12+**: For local development
+Or with mise:
 
-## 🛠️ Installation
+```bash
+mise run build-container
+```
 
-### Quick Start with Docker
+## Configuration
 
-1. **Clone the repository:**
-   ```bash
-   git clone <repository-url>
-   cd <repository-name>
-   ```
-
-2. **Set up environment:**
-   ```bash
-   # Create .env file
-   echo "IBMCLOUD_API_KEY=your_api_key_here" > .env
-   ```
-
-3. **Build and run:**
-   ```bash
-   mise run docker:build
-   mise run docker:run
-   ```
-
-### Local Development Setup
-
-1. **Install dependencies:**
-   ```bash
-   mise install
-   mise run uv:reqs
-   ```
-
-2. **Set environment variable:**
-   ```bash
-   export IBMCLOUD_API_KEY="your_api_key_here"
-   ```
-
-3. **Run locally:**
-   ```bash
-   python vpc_mcp_server.py
-   ```
-
-## 🔧 Configuration
-
-### Environment Variables
+The server requires one environment variable:
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `IBMCLOUD_API_KEY` | IBM Cloud API key with VPC permissions | ✅ |
-| `LOG_LEVEL` | Logging level (INFO, DEBUG, ERROR) | ❌ |
-| `PYTHONUNBUFFERED` | Unbuffered Python output | ❌ |
+| `IBMCLOUD_API_KEY` | IBM Cloud API key | Yes |
+| `LOG_LEVEL` | Logging level (INFO, DEBUG, ERROR) | No |
 
-### IBM Cloud API Key Setup
+## Claude Desktop
 
-1. Go to [IBM Cloud API Keys](https://cloud.ibm.com/iam/apikeys)
-2. Click **Create an API key**
-3. Provide a name and description
-4. Ensure the key has VPC access permissions
-5. Copy the API key (save it securely - it won't be shown again)
+Add the following to your `claude_desktop_config.json`:
 
-## 🐳 Docker Commands
-
-### Using mise tasks:
-```bash
-# Build Docker image with timestamp
-mise run build-container
-
-# Build and update Claude Desktop config
-mise run build-and-update
-
-# Quick rebuild
-mise run rebuild
-
-# Test container
-mise run test-container
+```json
+{
+  "mcpServers": {
+    "ibmcloud-vpc": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "IBMCLOUD_API_KEY",
+        "ibmcloud-vpc-mcp:latest"
+      ],
+      "env": {
+        "IBMCLOUD_API_KEY": "your_api_key_here"
+      }
+    }
+  }
+}
 ```
 
-### Manual Docker commands:
+## Claude Code
+
 ```bash
-# Build
-docker build -t ibmcloud-vpc-mcp:latest .
-
-# Run
-docker run -d --name vpc-mcp-server \
-  -e IBMCLOUD_API_KEY="${IBMCLOUD_API_KEY}" \
-  ibmcloud-vpc-mcp:latest
-
-# With docker-compose
-docker-compose up -d
+claude mcp add ibmcloud-vpc -- docker run --rm -i -e IBMCLOUD_API_KEY=your_api_key_here ibmcloud-vpc-mcp:latest
 ```
 
-## 📊 Available MCP Tools
+## Local Development
 
-### Core VPC Operations
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_regions` | List all IBM Cloud VPC regions | None |
-| `list_vpcs` | List VPCs (all regions or specific) | `region` (optional) |
-| `get_vpc` | Get detailed VPC information | `vpc_id`, `region` |
-| `get_vpc_resources_summary` | Complete VPC resource summary with security analysis | `vpc_id`, `region` |
-
-### Network Resources
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_subnets` | List subnets with filtering | `region`, `vpc_id` (optional) |
-| `list_instances` | List compute instances | `region`, `vpc_id` (optional) |
-| `list_instance_profiles` | List available instance profiles | `region` |
-| `list_public_gateways` | List public gateways | `region`, `vpc_id` (optional) |
-| `list_floating_ips` | List floating IPs | `region` |
-
-### Security Groups
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_security_groups` | List security groups | `region`, `vpc_id` (optional) |
-| `get_security_group` | Get detailed security group info | `security_group_id`, `region` |
-| `list_security_group_rules` | List rules for specific security group | `security_group_id`, `region` |
-
-### Security Analysis
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `analyze_ssh_security_groups` | Find SSH exposure to internet (0.0.0.0/0) | `region`, `vpc_id` (optional) |
-| `analyze_security_groups_by_protocol` | Custom protocol/port analysis | `region`, `protocol`, `port` (optional), `source_cidr` (optional) |
-
-### Routing Tables
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_routing_tables` | List routing tables in a VPC | `region`, `vpc_id` (required) |
-| `get_routing_table` | Get detailed routing table information | `vpc_id`, `routing_table_id`, `region` |
-| `find_routing_table_by_name` | Find routing table by name and return UUID | `region`, `vpc_id`, `name` |
-
-### Block Storage
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_volumes` | List block storage volumes | `region`, `attachment_state` (optional), `name` (optional) |
-| `list_volume_profiles` | List available volume profiles | `region` |
-| `get_volume` | Get detailed volume information | `volume_id`, `region` |
-| `analyze_storage_usage` | Analyze block storage usage | `region` |
-
-### File Storage
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_shares` | List file shares | `region`, `name` (optional), `resource_group_id` (optional) |
-| `get_share` | Get detailed file share information | `share_id`, `region` |
-| `list_share_profiles` | List available file share profiles | `region` |
-
-### Snapshots
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_snapshots` | List block storage snapshots | `region`, `name` (optional), `source_volume_id` (optional) |
-| `get_snapshot` | Get detailed snapshot information | `snapshot_id`, `region` |
-| `analyze_snapshot_usage` | Analyze snapshot usage and costs | `region` |
-
-### Backup Policies
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_backup_policies` | List backup policies | `region`, `name` (optional), `resource_group_id` (optional) |
-| `list_backup_policy_jobs` | List jobs for a backup policy | `backup_policy_id`, `region`, `status` (optional) |
-| `list_backup_policy_plans` | List plans for a backup policy | `backup_policy_id`, `region`, `name` (optional) |
-| `get_backup_policy_summary` | Get comprehensive backup policy information | `backup_policy_id`, `region` |
-| `analyze_backup_policies` | Analyze backup policy health and compliance | `region`, `resource_group_id` (optional) |
-
-### VPN Gateway Management
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_vpn_gateways` | List VPN gateways with optional VPC filtering | `region`, `vpc_id` (optional), `limit` (optional), `start` (optional) |
-| `get_vpn_gateway` | Get detailed VPN gateway information | `vpn_gateway_id`, `region` |
-| `get_ike_policy` | Get IKE policy details for VPN gateways | `ike_policy_id`, `region` |
-| `get_ipsec_policy` | Get IPsec policy details for VPN gateways | `ipsec_policy_id`, `region` |
-
-### VPN Server Management
-| Tool Name | Description | Key Parameters |
-|-----------|-------------|----------------|
-| `list_vpn_servers` | List VPN servers with optional name filtering | `region`, `name` (optional), `limit` (optional), `start` (optional) |
-| `get_vpn_server` | Get detailed VPN server info including authentication methods | `vpn_server_id`, `region` |
-| `get_vpn_server_client_configuration` | Get OpenVPN client configuration files | `vpn_server_id`, `region` |
-| `list_vpn_server_clients` | List clients connected to a VPN server | `vpn_server_id`, `region`, `limit` (optional), `start` (optional), `sort` (optional) |
-| `list_vpn_server_routes` | List routing configuration for VPN servers | `vpn_server_id`, `region`, `limit` (optional), `start` (optional) |
-
-## 🎯 Usage Examples
-
-### Basic VPC Discovery
 ```bash
-# List all regions
-list_regions
-
-# List VPCs in specific region
-list_vpcs --region us-south
-
-# Get complete VPC summary
-get_vpc_resources_summary --vpc_id vpc-12345 --region us-south
+pip install -r requirements.txt
+export IBMCLOUD_API_KEY="your_api_key_here"
+python vpc_mcp_server.py
 ```
 
-### Security Analysis
-```bash
-# Find SSH exposure across all VPCs
-analyze_ssh_security_groups --region us-south
+## License
 
-# Find RDP exposure
-analyze_security_groups_by_protocol --region us-south --protocol tcp --port 3389
-
-# Get detailed security group information
-get_security_group --security_group_id sg-12345 --region us-south
-```
-
-### Routing Table Management
-```bash
-# List routing tables in a VPC
-list_routing_tables --region us-south --vpc_id vpc-12345
-
-# Find routing table by name
-find_routing_table_by_name --region us-south --vpc_id vpc-12345 --name "main-routing-table"
-
-# Get detailed routing table information
-get_routing_table --vpc_id vpc-12345 --routing_table_id rt-12345 --region us-south
-```
-
-### Storage Management
-```bash
-# List all volumes
-list_volumes --region us-south
-
-# List snapshots
-list_snapshots --region us-south
-
-# Analyze storage usage
-analyze_storage_usage --region us-south
-
-# Analyze snapshot usage
-analyze_snapshot_usage --region us-south
-```
-
-### Backup Policy Management
-```bash
-# List backup policies
-list_backup_policies --region us-south
-
-# Get backup policy summary
-get_backup_policy_summary --backup_policy_id policy-12345 --region us-south
-
-# Analyze backup policies
-analyze_backup_policies --region us-south
-```
-
-### VPN Management
-```bash
-# List VPN gateways
-list_vpn_gateways --region us-south
-
-# List VPN gateways for specific VPC
-list_vpn_gateways --region us-south --vpc_id vpc-12345
-
-# Get VPN gateway details
-get_vpn_gateway --vpn_gateway_id vpn-gateway-12345 --region us-south
-
-# Get IKE/IPsec policy details
-get_ike_policy --ike_policy_id ike-policy-12345 --region us-south
-get_ipsec_policy --ipsec_policy_id ipsec-policy-12345 --region us-south
-
-# List VPN servers
-list_vpn_servers --region us-south
-
-# Get VPN server details with authentication info
-get_vpn_server --vpn_server_id vpn-server-12345 --region us-south
-
-# Get OpenVPN client configuration
-get_vpn_server_client_configuration --vpn_server_id vpn-server-12345 --region us-south
-
-# List connected clients
-list_vpn_server_clients --vpn_server_id vpn-server-12345 --region us-south
-
-# List VPN server routes
-list_vpn_server_routes --vpn_server_id vpn-server-12345 --region us-south
-```
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/new-analysis`
-3. Make your changes in `utils.py` or `vpc_mcp_server.py`
-4. Test with: `mise run build-container && mise run test-container`
-5. Submit a pull request
-
-## 📚 Additional Resources
-
-- **[CLAUDE.md](./debug/CLAUDE.md)**: Comprehensive development guide for Claude Code instances
-- **[TROUBLESHOOTING.md](./TROUBLESHOOTING.md)**: Detailed troubleshooting guide
-- **[test_all_tools.md](./debug/test_all_tools.md)**: Commands to test all tools after deployment
-
-## 📝 License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## 🏷️ Version History
-
-- **v1.0.0**: Initial release with basic VPC management
-- **v1.1.0**: Added security analysis features
-- **v1.2.0**: Enhanced Docker support and mise tasks
-- **v1.3.0**: Multi-region support and comprehensive summaries
-- **v1.4.0**: Added backup policy management and analysis features
-- **v1.5.0**: Added routing table lookup, snapshots, and improved storage tools
-- **v1.6.0**: Comprehensive VPN management (gateways, servers, clients, policies, configuration)
-
----
-
-**Built with ❤️ for IBM Cloud VPC management and security analysis**
+MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
 httpx-sse==0.4.0
+ibm-cloud-networking-services==0.29.0
 ibm-cloud-sdk-core==3.23.0
 ibm-platform-services==0.66.0
 ibm-vpc==0.28.0

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import ibm_vpc
 from ibm_cloud_sdk_core import ApiException
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_networking_services import TransitGatewayApisV1
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,17 @@ class VPCManager:
         self.authenticator = authenticator
         self.vpc_clients = {}  # Cache VPC clients by region
         self.regions = []
+        self._tgw_client: Optional[TransitGatewayApisV1] = None
 
+
+    def _get_tgw_client(self) -> TransitGatewayApisV1:
+        """Get or create the (global) Transit Gateway client."""
+        if self._tgw_client is None:
+            self._tgw_client = TransitGatewayApisV1(
+                version='2024-06-20',
+                authenticator=self.authenticator,
+            )
+        return self._tgw_client
 
     def _get_vpc_client(self, region: str) -> ibm_vpc.VpcV1:
         """Get or create VPC client for a specific region"""
@@ -1309,6 +1320,74 @@ class VPCManager:
             logger.error(f"Error analyzing flow log collectors in region {region}: {e}")
             raise
 
+    # ------------------------------------------------------------------
+    # Transit Gateway methods
+    # ------------------------------------------------------------------
+
+    async def list_transit_gateways(self, limit: int = 50,
+                                    start: Optional[str] = None) -> Dict[str, Any]:
+        """List all Transit Gateways (global service, not region-scoped)."""
+        try:
+            client = self._get_tgw_client()
+            response = client.list_transit_gateways(
+                limit=limit,
+                start=start,
+            ).get_result()
+            gateways = response.get('transit_gateways', [])
+            return {
+                'transit_gateways': gateways,
+                'count': len(gateways),
+                'total_count': response.get('total_count', len(gateways)),
+                'limit': response.get('limit', limit),
+            }
+        except ApiException as e:
+            logger.error(f"Error listing transit gateways: {e}")
+            raise
+
+    async def get_transit_gateway(self, transit_gateway_id: str) -> Dict[str, Any]:
+        """Get details for a specific Transit Gateway."""
+        try:
+            client = self._get_tgw_client()
+            return client.get_transit_gateway(transit_gateway_id).get_result()
+        except ApiException as e:
+            logger.error(f"Error getting transit gateway {transit_gateway_id}: {e}")
+            raise
+
+    async def list_transit_gateway_connections(self, transit_gateway_id: str,
+                                               name: Optional[str] = None,
+                                               limit: int = 50,
+                                               start: Optional[str] = None) -> Dict[str, Any]:
+        """List connections for a Transit Gateway."""
+        try:
+            client = self._get_tgw_client()
+            response = client.list_transit_gateway_connections(
+                transit_gateway_id=transit_gateway_id,
+                name=name,
+                limit=limit,
+                start=start,
+            ).get_result()
+            connections = response.get('connections', [])
+            return {
+                'transit_gateway_id': transit_gateway_id,
+                'connections': connections,
+                'count': len(connections),
+                'total_count': response.get('total_count', len(connections)),
+                'limit': response.get('limit', limit),
+            }
+        except ApiException as e:
+            logger.error(f"Error listing connections for transit gateway {transit_gateway_id}: {e}")
+            raise
+
+    async def get_transit_gateway_connection(self, transit_gateway_id: str,
+                                             connection_id: str) -> Dict[str, Any]:
+        """Get details for a specific Transit Gateway connection."""
+        try:
+            client = self._get_tgw_client()
+            return client.get_transit_gateway_connection(transit_gateway_id, connection_id).get_result()
+        except ApiException as e:
+            logger.error(f"Error getting connection {connection_id} for transit gateway {transit_gateway_id}: {e}")
+            raise
+
     async def list_vpn_server_routes(self, vpn_server_id: str, region: str, limit: int = 50, start: Optional[str] = None) -> Dict[str, Any]:
         """List routes for a VPN server"""
         try:
@@ -1436,7 +1515,7 @@ def analyze_backup_policy_health(policy: Dict[str, Any], jobs: List[Dict[str, An
         # Check for very old last job
         if recent_jobs:
             try:
-                from datetime import datetime, timedelta
+                from datetime import datetime
                 last_job_date = datetime.fromisoformat(recent_jobs[0]['created_at'].replace('Z', '+00:00'))
                 days_ago = (datetime.now().astimezone() - last_job_date).days
                 

--- a/vpc_mcp_server.py
+++ b/vpc_mcp_server.py
@@ -1106,6 +1106,83 @@ class VPCMCPServer:
                 "required": ["region"]
             }
         ),
+        # Transit Gateway tools (global service — no region parameter)
+        Tool(
+            name="list_transit_gateways",
+            description="List all IBM Cloud Transit Gateways. Transit Gateway is a global service so no region is required.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "number",
+                        "description": "Maximum number of gateways to return (default 50)"
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "Pagination start token"
+                    }
+                },
+                "required": []
+            }
+        ),
+        Tool(
+            name="get_transit_gateway",
+            description="Get detailed information about a specific Transit Gateway, including its routing type, location, and lifecycle state.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "transit_gateway_id": {
+                        "type": "string",
+                        "description": "Transit Gateway ID"
+                    }
+                },
+                "required": ["transit_gateway_id"]
+            }
+        ),
+        Tool(
+            name="list_transit_gateway_connections",
+            description="List all connections attached to a Transit Gateway. Connections represent VPCs, classic infrastructure, Direct Link, or Power Virtual Server networks connected through the gateway.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "transit_gateway_id": {
+                        "type": "string",
+                        "description": "Transit Gateway ID"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Filter connections by name (optional)"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "description": "Maximum number of connections to return (default 50)"
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "Pagination start token"
+                    }
+                },
+                "required": ["transit_gateway_id"]
+            }
+        ),
+        Tool(
+            name="get_transit_gateway_connection",
+            description="Get detailed information about a specific connection on a Transit Gateway.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "transit_gateway_id": {
+                        "type": "string",
+                        "description": "Transit Gateway ID"
+                    },
+                    "connection_id": {
+                        "type": "string",
+                        "description": "Connection ID"
+                    }
+                },
+                "required": ["transit_gateway_id", "connection_id"]
+            }
+        ),
     ]
 
 
@@ -1379,6 +1456,28 @@ class VPCMCPServer:
                     result = await self.vpc_manager.analyze_flow_log_collectors(
                         arguments['region'],
                         arguments.get('vpc_id')
+                    )
+                # Transit Gateway handlers
+                elif name == "list_transit_gateways":
+                    result = await self.vpc_manager.list_transit_gateways(
+                        arguments.get('limit', 50),
+                        arguments.get('start'),
+                    )
+                elif name == "get_transit_gateway":
+                    result = await self.vpc_manager.get_transit_gateway(
+                        arguments['transit_gateway_id'],
+                    )
+                elif name == "list_transit_gateway_connections":
+                    result = await self.vpc_manager.list_transit_gateway_connections(
+                        arguments['transit_gateway_id'],
+                        arguments.get('name'),
+                        arguments.get('limit', 50),
+                        arguments.get('start'),
+                    )
+                elif name == "get_transit_gateway_connection":
+                    result = await self.vpc_manager.get_transit_gateway_connection(
+                        arguments['transit_gateway_id'],
+                        arguments['connection_id'],
                     )
                 else:
                     raise ValueError(f"Unknown tool: {name}")


### PR DESCRIPTION
Adds four new tools: list_transit_gateways, get_transit_gateway, list_transit_gateway_connections, and get_transit_gateway_connection. Uses TransitGatewayApisV1 from ibm-cloud-networking-services (0.29.0). Transit Gateway is a global service so no region parameter is required.

Also trims README to essential build/run/config information.